### PR TITLE
Changed how relics on the ground are represented

### DIFF
--- a/MineInAbyss-API/src/main/java/com/derongan/minecraft/mineinabyss/World/ChunkEntity.java
+++ b/MineInAbyss-API/src/main/java/com/derongan/minecraft/mineinabyss/World/ChunkEntity.java
@@ -1,0 +1,56 @@
+package com.derongan.minecraft.mineinabyss.World;
+
+import org.bukkit.World;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.bukkit.entity.Entity;
+
+/**
+ * An entity that can be loaded/unloaded out of sync with chunk loading.
+ * Implementations are responsible for serializing the entity for saving.
+ */
+public interface ChunkEntity extends ConfigurationSerializable {
+    final String TIME_REMAINING_KEY = "time_remaining";
+    final String TIME_SERIALIZED_KEY = "time_serialized";
+    final String X_KEY = "x";
+    final String Y_KEY = "y";
+    final String Z_KEY = "z";
+
+    /**
+     * @return amount of time in seconds remaining before this entity despawns. -1 if the entity is immortal.
+     */
+    long getTimeRemaining();
+
+
+    /**
+     * @return the system time in ms when this method was called
+     */
+    long getCurrentTime();
+
+    /**
+     * Creates the associated entity (on chunk load for example) at location
+     * @param world
+     */
+    Entity createEntity(World world);
+
+    /**
+     * Destroys the associated entity (on chunk unload for example)
+     */
+    void destroyEntity();
+
+    Entity getEntity();
+
+    /**
+     * Get the X location of the entity
+     */
+    int getX();
+
+    /**
+     * Get the Y location of the entity
+     */
+    int getY();
+
+    /**
+     * Get the Z location of the entity
+     */
+    int getZ();
+}

--- a/MineInAbyss-API/src/main/java/com/derongan/minecraft/mineinabyss/World/EntityChunkManager.java
+++ b/MineInAbyss-API/src/main/java/com/derongan/minecraft/mineinabyss/World/EntityChunkManager.java
@@ -1,0 +1,18 @@
+package com.derongan.minecraft.mineinabyss.World;
+
+import org.bukkit.Chunk;
+import org.bukkit.entity.Entity;
+
+/**
+ * Manages special entities on chunks. Special entities are those that we want to be able
+ * to spawn/despawn while a chunk is not loaded
+ */
+public interface EntityChunkManager {
+    void loadChunk(Chunk chunk);
+
+    void unloadChunk(Chunk chunk);
+
+    void addEntity(Chunk chunk, ChunkEntity chunkEntity);
+
+    void removeEntity(Chunk chunk, Entity entity);
+}

--- a/MineInAbyss/src/main/java/com/derongan/minecraft/mineinabyss/AbyssContext.java
+++ b/MineInAbyss/src/main/java/com/derongan/minecraft/mineinabyss/AbyssContext.java
@@ -3,6 +3,8 @@ package com.derongan.minecraft.mineinabyss;
 import com.derongan.minecraft.mineinabyss.Player.PlayerData;
 import com.derongan.minecraft.mineinabyss.World.AbyssWorldManager;
 import com.derongan.minecraft.mineinabyss.World.AbyssWorldManagerImpl;
+import com.derongan.minecraft.mineinabyss.World.EntityChunkManager;
+import com.derongan.minecraft.mineinabyss.World.EntityChunkManagerImpl;
 import org.bukkit.configuration.Configuration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.Plugin;
@@ -25,10 +27,12 @@ public class AbyssContext {
     private Connection connection;
 
     private AbyssWorldManager worldManager;
+    private EntityChunkManager entityChunkManager;
 
     public AbyssContext(Configuration config) {
         this.config = config;
         worldManager = new AbyssWorldManagerImpl(getConfig());
+        entityChunkManager = new EntityChunkManagerImpl(this);
     }
 
     public Plugin getPlugin() {
@@ -57,5 +61,9 @@ public class AbyssContext {
 
     public AbyssWorldManager getWorldManager() {
         return worldManager;
+    }
+
+    public EntityChunkManager getEntityChunkManager() {
+        return entityChunkManager;
     }
 }

--- a/MineInAbyss/src/main/java/com/derongan/minecraft/mineinabyss/Configuration/ConfigurationConstants.java
+++ b/MineInAbyss/src/main/java/com/derongan/minecraft/mineinabyss/Configuration/ConfigurationConstants.java
@@ -2,4 +2,5 @@ package com.derongan.minecraft.mineinabyss.Configuration;
 
 public class ConfigurationConstants {
     public final static String PLAYER_DATA_DIR = "player";
+    public final static String WORLD_ENTITY_DATA_DIR = "world";
 }

--- a/MineInAbyss/src/main/java/com/derongan/minecraft/mineinabyss/MineInAbyss.java
+++ b/MineInAbyss/src/main/java/com/derongan/minecraft/mineinabyss/MineInAbyss.java
@@ -9,11 +9,16 @@ import com.derongan.minecraft.mineinabyss.Player.PlayerListener;
 import com.derongan.minecraft.mineinabyss.Relic.Loading.RelicLoader;
 import com.derongan.minecraft.mineinabyss.Relic.RelicCommandExecutor;
 import com.derongan.minecraft.mineinabyss.Relic.RelicDecayTask;
+import com.derongan.minecraft.mineinabyss.Relic.RelicGroundEntity;
 import com.derongan.minecraft.mineinabyss.Relic.RelicUseListener;
+import com.derongan.minecraft.mineinabyss.World.EntityChunkListener;
 import com.derongan.minecraft.mineinabyss.World.WorldCommandExecutor;
 import org.bukkit.Bukkit;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.configuration.serialization.ConfigurationSerialization;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.yaml.snakeyaml.Yaml;
 
 import java.io.IOException;
 
@@ -33,6 +38,7 @@ public final class MineInAbyss extends JavaPlugin {
 
         getServer().getPluginManager().registerEvents(new PlayerListener(context), this);
         getServer().getPluginManager().registerEvents(new AscensionListener(context), this);
+        getServer().getPluginManager().registerEvents(new EntityChunkListener(context), this);
 
         PlayerDataConfigManager manager = new PlayerDataConfigManager(context);
 
@@ -49,6 +55,7 @@ public final class MineInAbyss extends JavaPlugin {
         this.getCommand("relic").setExecutor(relicCommandExecutor);
         this.getCommand("relicreload").setExecutor(relicCommandExecutor);
         this.getCommand("relics").setExecutor(relicCommandExecutor);
+        this.getCommand("yolo").setExecutor(relicCommandExecutor);
 
         WorldCommandExecutor worldCommandExecutor = new WorldCommandExecutor(context);
 
@@ -59,6 +66,8 @@ public final class MineInAbyss extends JavaPlugin {
 
         this.getCommand("curseon").setExecutor(ascensionCommandExecutor);
         this.getCommand("curseoff").setExecutor(ascensionCommandExecutor);
+
+        ConfigurationSerialization.registerClass(RelicGroundEntity.class);
 
         RelicLoader.loadAllRelics(context);
     }
@@ -85,5 +94,9 @@ public final class MineInAbyss extends JavaPlugin {
         Plugin plugin = Bukkit.getServer().getPluginManager().getPlugin("MineInAbyss");
 
         return (MineInAbyss) plugin;
+    }
+
+    public AbyssContext getContext() {
+        return context;
     }
 }

--- a/MineInAbyss/src/main/java/com/derongan/minecraft/mineinabyss/Relic/Behaviour/Behaviours/LootableRelicBehaviour.java
+++ b/MineInAbyss/src/main/java/com/derongan/minecraft/mineinabyss/Relic/Behaviour/Behaviours/LootableRelicBehaviour.java
@@ -1,8 +1,11 @@
 package com.derongan.minecraft.mineinabyss.Relic.Behaviour.Behaviours;
 
+import com.derongan.minecraft.mineinabyss.MineInAbyss;
 import com.derongan.minecraft.mineinabyss.Relic.Behaviour.ArmorStandBehaviour;
 import com.derongan.minecraft.mineinabyss.Relic.Behaviour.DecayableRelicBehaviour;
+import com.derongan.minecraft.mineinabyss.World.EntityChunkManager;
 import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
 import org.bukkit.event.player.PlayerInteractAtEntityEvent;
 
 /**
@@ -15,8 +18,18 @@ public class LootableRelicBehaviour implements DecayableRelicBehaviour, ArmorSta
         ArmorStandBehaviour.registeredRelics.remove(e.getRightClicked().getUniqueId());
         ArmorStand as = (ArmorStand) e.getRightClicked();
         e.getPlayer().getInventory().addItem(as.getItemInHand());
-        as.remove();
+
+        removeFromWorld(e.getRightClicked());
+
         e.setCancelled(true);
+    }
+
+    private void removeFromWorld(Entity e){
+        EntityChunkManager manager = MineInAbyss.getInstance().getContext().getEntityChunkManager();
+        manager.removeEntity(e.getLocation().getChunk(), e);
+        e.remove();
+
+        System.out.println("Removing relic");
     }
 
     @Override

--- a/MineInAbyss/src/main/java/com/derongan/minecraft/mineinabyss/Relic/Distribution/DistributionTask.java
+++ b/MineInAbyss/src/main/java/com/derongan/minecraft/mineinabyss/Relic/Distribution/DistributionTask.java
@@ -36,6 +36,6 @@ public class DistributionTask extends BukkitRunnable {
     }
 
     void spawnLootableRelic(Location location, RelicType relicType) {
-        lootableRelicType.spawnLootableRelic(location, relicType, TickUtils.milisecondsToTicks(10000));
+//        lootableRelicType.spawnLootableRelic(location, relicType, TickUtils.milisecondsToTicks(10000));
     }
 }

--- a/MineInAbyss/src/main/java/com/derongan/minecraft/mineinabyss/Relic/RelicCommandExecutor.java
+++ b/MineInAbyss/src/main/java/com/derongan/minecraft/mineinabyss/Relic/RelicCommandExecutor.java
@@ -3,6 +3,9 @@ package com.derongan.minecraft.mineinabyss.Relic;
 import com.derongan.minecraft.mineinabyss.AbyssContext;
 import com.derongan.minecraft.mineinabyss.Relic.Loading.RelicLoader;
 import com.derongan.minecraft.mineinabyss.Relic.Relics.RelicType;
+import com.derongan.minecraft.mineinabyss.Relic.Relics.StandardRelicType;
+import com.derongan.minecraft.mineinabyss.World.ChunkEntity;
+import org.bukkit.Location;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -43,9 +46,21 @@ public class RelicCommandExecutor implements CommandExecutor {
             if(label.equals("relics")){
                 player.sendMessage("Relics: " + RelicType.registeredRelics.values().stream()
                         .map(RelicType::getName)
-                        .map(a->a.replace(" ", "_"))
+                        .map(a->a.replace(  " ", "_"))
                         .collect(Collectors.joining(", ")));
                 return true;
+            }
+
+            if(label.equals("yolo")){
+                Location location = player.getLocation();
+                RelicType blaze = StandardRelicType.BLAZE_REAP;
+                ChunkEntity entity = new RelicGroundEntity(blaze,
+                        location.getBlockX(),
+                        location.getBlockY(),
+                        location.getBlockZ());
+                entity.createEntity(location.getWorld());
+
+                context.getEntityChunkManager().addEntity(location.getChunk(), entity);
             }
         }
 

--- a/MineInAbyss/src/main/java/com/derongan/minecraft/mineinabyss/Relic/RelicGroundEntity.java
+++ b/MineInAbyss/src/main/java/com/derongan/minecraft/mineinabyss/Relic/RelicGroundEntity.java
@@ -1,0 +1,121 @@
+package com.derongan.minecraft.mineinabyss.Relic;
+
+import com.derongan.minecraft.mineinabyss.Relic.Behaviour.ArmorStandBehaviour;
+import com.derongan.minecraft.mineinabyss.Relic.Behaviour.Behaviours.LootableRelicBehaviour;
+import com.derongan.minecraft.mineinabyss.Relic.Relics.LootableRelicType;
+import com.derongan.minecraft.mineinabyss.Relic.Relics.RelicType;
+import com.derongan.minecraft.mineinabyss.World.ChunkEntityImpl;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.util.EulerAngle;
+import org.bukkit.util.Vector;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Represents an entity that invisibly holds a relic
+ */
+public class RelicGroundEntity extends ChunkEntityImpl {
+    public static final String NAME_KEY = "name";
+    public static final String LORE_KEY = "lore";
+    public static final String MAT_KEY = "material";
+    public static final String DURABILITY_KEY = "durability";
+    public static final String RARITY_KEY = "rarity";
+
+    private static LootableRelicBehaviour behaviour = new LootableRelicBehaviour();
+    private static RelicType lootableType = new LootableRelicType();
+
+    private String name;
+    private String lore;
+    private String mat;
+    private short dur;
+    private String rarity;
+
+    public RelicGroundEntity(String name, String lore, String mat, short dur, String rarity, int x, int y, int z) {
+        super(-1, x, y, z);
+        this.name = name;
+        this.lore = lore;
+        this.mat = mat;
+        this.dur = dur;
+        this.rarity = rarity;
+    }
+
+    public RelicGroundEntity(RelicType relicType, int x, int y, int z) {
+        super(-1, x, y, z);
+
+        this.name = relicType.getName();
+        this.lore = relicType.getLore().stream().collect(Collectors.joining("\n"));
+        this.mat = relicType.getMaterial().name();
+        this.dur = relicType.getDurability();
+        this.rarity = relicType.getRarity().name();
+    }
+
+    //Deserialization constructor
+    public RelicGroundEntity(Map<String, Object> serializedMap) {
+        super(((Number) serializedMap.get(TIME_REMAINING_KEY)).longValue(),
+                ((Number) serializedMap.get(X_KEY)).intValue(),
+                ((Number) serializedMap.get(Y_KEY)).intValue(),
+                ((Number) serializedMap.get(Z_KEY)).intValue());
+
+        name = (String) serializedMap.get(NAME_KEY);
+        lore = (String) serializedMap.get(LORE_KEY);
+        mat = (String) serializedMap.get(MAT_KEY);
+        dur = (short) ((Number) serializedMap.get(DURABILITY_KEY)).shortValue();
+        rarity = (String) serializedMap.get(RARITY_KEY);
+    }
+
+    @Override
+    public Map<String, Object> serialize() {
+        Map<String, Object> serializedMap = new HashMap<>();
+
+        serializedMap.put(TIME_REMAINING_KEY, getTimeRemaining());
+        serializedMap.put(TIME_SERIALIZED_KEY, getCurrentTime());
+
+        serializedMap.put(NAME_KEY, name);
+        serializedMap.put(LORE_KEY, lore);
+        serializedMap.put(MAT_KEY, mat);
+        serializedMap.put(DURABILITY_KEY, dur);
+        serializedMap.put(RARITY_KEY, rarity);
+
+        serializedMap.put(X_KEY, getX());
+        serializedMap.put(Y_KEY, getY());
+        serializedMap.put(Z_KEY, getZ());
+
+        return serializedMap;
+    }
+
+    @Override
+    public Entity makeEntity(Location loc) {
+        ArmorStand as = (ArmorStand) loc.getWorld().spawnEntity(loc.add(.5, -1.4, .5).setDirection(new Vector(0, 0, 0)), EntityType.ARMOR_STAND);
+        as.setVisible(false);
+        as.setCollidable(false);
+        as.setRightArmPose(new EulerAngle(-Math.PI / 2, -Math.PI / 2, 0));
+        as.setInvulnerable(true);
+        as.setGravity(false);
+
+        ItemStack item = new org.bukkit.inventory.ItemStack(Material.valueOf(mat), 1, dur);
+
+        ItemMeta meta = item.getItemMeta();
+        meta.setUnbreakable(true);
+        meta.setLore(Arrays.asList(lore.split("\n")));
+
+        meta.setDisplayName(RelicRarity.valueOf(rarity).getColor() + name);
+
+
+        item.setItemMeta(meta);
+
+        as.setItemInHand(item);
+
+        behaviour.registerRelic(as.getUniqueId(), lootableType);
+
+        return as;
+    }
+}

--- a/MineInAbyss/src/main/java/com/derongan/minecraft/mineinabyss/Relic/Relics/LootableRelicType.java
+++ b/MineInAbyss/src/main/java/com/derongan/minecraft/mineinabyss/Relic/Relics/LootableRelicType.java
@@ -51,27 +51,4 @@ public class LootableRelicType implements RelicType {
     public RelicRarity getRarity() {
         return null;
     }
-
-    public void spawnLootableRelic(Location location, RelicType type, int lifetime) {
-        ItemStack item = type.getItem();
-
-        ArmorStand as = (ArmorStand) location.getWorld().spawnEntity(location.add(.5, -1.4, .5).setDirection(new Vector(0, 0, 0)), EntityType.ARMOR_STAND);
-        as.setGravity(false);
-        as.setArms(true);
-        as.setVisible(false);
-        as.setCollidable(false);
-        as.setItemInHand(item);
-        as.setRightArmPose(new EulerAngle(-Math.PI / 2, -Math.PI / 2, 0));
-
-        if (type.getRarity() == RelicRarity.SPECIAL_GRADE) {
-            as.setCustomName(ChatColor.GRAY.toString() + ChatColor.MAGIC + type.getName());
-        } else {
-            as.setCustomName(ChatColor.GRAY + type.getName());
-        }
-        as.setCustomNameVisible(true);
-        as.setInvulnerable(true);
-
-        DecayableRelicBehaviour.registerRelic(as, lifetime, this);
-        behaviour.registerRelic(as.getUniqueId(), this);
-    }
 }

--- a/MineInAbyss/src/main/java/com/derongan/minecraft/mineinabyss/World/ChunkEntityImpl.java
+++ b/MineInAbyss/src/main/java/com/derongan/minecraft/mineinabyss/World/ChunkEntityImpl.java
@@ -1,0 +1,66 @@
+package com.derongan.minecraft.mineinabyss.World;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+
+public abstract class ChunkEntityImpl implements ChunkEntity {
+    private long timeRemaining;
+    private Entity theEntity;
+    private int x;
+    private int z;
+    private int y;
+
+    public ChunkEntityImpl(long timeRemaining, int x, int y, int z) {
+        this.timeRemaining = timeRemaining;
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+
+    @Override
+    public long getTimeRemaining(){
+        return timeRemaining;
+    }
+
+    @Override
+    public long getCurrentTime(){
+        return System.currentTimeMillis();
+    }
+
+    @Override
+    public void destroyEntity() {
+        theEntity.remove();
+    }
+
+    // This is a dubious decision
+    @Override
+    public Entity createEntity(World world) {
+        Location location = new Location(world, getX(), getY(), getZ());
+        theEntity = makeEntity(location);
+
+        return theEntity;
+    }
+
+    @Override
+    public Entity getEntity() {
+        return theEntity;
+    }
+
+    protected abstract Entity makeEntity(Location location);
+
+    @Override
+    public int getX() {
+        return x;
+    }
+
+    @Override
+    public int getY() {
+        return y;
+    }
+
+    @Override
+    public int getZ() {
+        return z;
+    }
+}

--- a/MineInAbyss/src/main/java/com/derongan/minecraft/mineinabyss/World/EntityChunkListener.java
+++ b/MineInAbyss/src/main/java/com/derongan/minecraft/mineinabyss/World/EntityChunkListener.java
@@ -1,0 +1,27 @@
+package com.derongan.minecraft.mineinabyss.World;
+
+import com.derongan.minecraft.mineinabyss.AbyssContext;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.world.ChunkLoadEvent;
+import org.bukkit.event.world.ChunkUnloadEvent;
+
+public class EntityChunkListener implements Listener {
+    private EntityChunkManager manager;
+    private AbyssContext context;
+
+    public EntityChunkListener(AbyssContext context) {
+        this.manager = context.getEntityChunkManager();
+        this.context = context;
+    }
+
+    @EventHandler
+    public void onChunkLoad(ChunkLoadEvent event) {
+        manager.loadChunk(event.getChunk());
+    }
+
+    @EventHandler
+    public void onChunkUnload(ChunkUnloadEvent event) {
+        manager.unloadChunk(event.getChunk());
+    }
+}

--- a/MineInAbyss/src/main/java/com/derongan/minecraft/mineinabyss/World/EntityChunkManagerImpl.java
+++ b/MineInAbyss/src/main/java/com/derongan/minecraft/mineinabyss/World/EntityChunkManagerImpl.java
@@ -1,0 +1,102 @@
+package com.derongan.minecraft.mineinabyss.World;
+
+import com.derongan.minecraft.mineinabyss.AbyssContext;
+import org.bukkit.Chunk;
+import org.bukkit.entity.Entity;
+
+
+import java.io.IOException;
+import java.util.*;
+
+public class EntityChunkManagerImpl implements EntityChunkManager {
+    private Map<ChunkKey, Collection<ChunkEntity>> chunkInfoMap;
+    private Map<UUID, ChunkEntity> chunkEntityMap;
+    private AbyssWorldManager manager;
+    private AbyssContext context;
+    private WorldDataConfigManager configManager;
+
+    public EntityChunkManagerImpl(AbyssContext context) {
+        chunkInfoMap = new HashMap<>(100);
+        chunkEntityMap = new HashMap<>(100);
+        configManager = new WorldDataConfigManager(context);
+
+        this.context = context;
+        this.manager = context.getWorldManager();
+    }
+
+    @Override
+    public void loadChunk(Chunk chunk) {
+        Collection<ChunkEntity> chunkEntities = configManager.loadChunkData(chunk);
+        chunkInfoMap.put(new ChunkKey(chunk), chunkEntities);
+
+        chunkEntities.forEach((a) -> {
+            Entity e = a.createEntity(chunk.getWorld());
+            chunkEntityMap.put(e.getUniqueId(), a);
+        });
+    }
+
+    @Override
+    public void unloadChunk(Chunk chunk) {
+        Collection<ChunkEntity> entities = chunkInfoMap.getOrDefault(new ChunkKey(chunk), Collections.emptyList());
+        chunkInfoMap.remove(new ChunkKey(chunk));
+
+        try {
+            configManager.saveChunkData(chunk, entities);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        entities.forEach(a->{
+            chunkEntityMap.remove(a.getEntity().getUniqueId());
+            a.destroyEntity();
+        });
+    }
+
+    @Override
+    public void addEntity(Chunk chunk, ChunkEntity chunkEntity) {
+        ChunkKey key = new ChunkKey(chunk);
+
+        chunkInfoMap.computeIfAbsent(key, (a) -> new ArrayList<>());
+
+        chunkInfoMap.get(key).add(chunkEntity);
+
+        chunkEntityMap.put(chunkEntity.getEntity().getUniqueId(), chunkEntity);
+    }
+
+    @Override
+    public void removeEntity(Chunk chunk, Entity entity) {
+        ChunkEntity e = chunkEntityMap.get(entity.getUniqueId());
+        chunkInfoMap.get(new ChunkKey(chunk)).remove(e);
+        chunkEntityMap.remove(entity.getUniqueId());
+        e.destroyEntity();
+    }
+
+    private class ChunkKey {
+        int x;
+        int z;
+        String worldName;
+
+        ChunkKey(Chunk chunk) {
+            this.x = chunk.getX();
+            this.z = chunk.getZ();
+
+            this.worldName = chunk.getWorld().getName();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof ChunkKey)) return false;
+            ChunkKey key = (ChunkKey) o;
+            return x == key.x &&
+                    z == key.z &&
+                    Objects.equals(worldName, key.worldName);
+        }
+
+        @Override
+        public int hashCode() {
+
+            return Objects.hash(x, z, worldName);
+        }
+    }
+}

--- a/MineInAbyss/src/main/java/com/derongan/minecraft/mineinabyss/World/WorldDataConfigManager.java
+++ b/MineInAbyss/src/main/java/com/derongan/minecraft/mineinabyss/World/WorldDataConfigManager.java
@@ -1,0 +1,59 @@
+package com.derongan.minecraft.mineinabyss.World;
+
+import com.derongan.minecraft.mineinabyss.AbyssContext;
+import com.derongan.minecraft.mineinabyss.Configuration.ConfigurationConstants;
+import com.derongan.minecraft.mineinabyss.MineInAbyss;
+import com.google.common.annotations.VisibleForTesting;
+import org.bukkit.Chunk;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+public class WorldDataConfigManager {
+    private AbyssContext context;
+    private static final String ENTITIES_KEY = "entities";
+
+    public WorldDataConfigManager(AbyssContext context) {
+        this.context = context;
+    }
+
+    public Collection<ChunkEntity> loadChunkData(Chunk chunk){
+        Path path = getChunkDataPath(chunk);
+
+        if(path.toFile().exists()){
+            YamlConfiguration config = YamlConfiguration.loadConfiguration(path.toFile());
+            return (Collection<ChunkEntity>) config.getList(ENTITIES_KEY);
+        } else {
+            return new ArrayList<>();
+        }
+    }
+
+    public void saveChunkData(Chunk chunk, Collection<ChunkEntity> entities) throws IOException {
+        Path path = getChunkDataPath(chunk);
+
+        // Recreate directories if missing
+        path.toFile().getParentFile().mkdirs();
+
+        YamlConfiguration config = new YamlConfiguration();
+        config.set(ENTITIES_KEY, entities);
+
+        config.save(path.toFile());
+    }
+
+    @VisibleForTesting
+    Path getChunkDataPath(Chunk chunk) {
+        String worldDir = chunk.getWorld().getName();
+        int x = chunk.getX();
+        int z = chunk.getZ();
+
+        return MineInAbyss.getInstance().getDataFolder()
+                .toPath()
+                .resolve(ConfigurationConstants.WORLD_ENTITY_DATA_DIR)
+                .resolve(worldDir)
+                .resolve(String.format("%d_%d.yml", x, z));
+    }
+}

--- a/MineInAbyss/src/main/resources/plugin.yml
+++ b/MineInAbyss/src/main/resources/plugin.yml
@@ -27,3 +27,6 @@ commands:
   curseoff:
     description: Turn off curse
     usage: /curseoff
+  yolo:
+    description: Testing
+    usage: /yolo


### PR DESCRIPTION
Hey @0ffz first big real merge request Im going to put by you.

This change adds the concept of managed entities in the world that are tied to a chunk. They are loaded/unloaded when the chunk is loaded/unloaded. We serialize them and store them in the plugin dir under world/worldname/chunk_coords.yml.

I am not sure if this will be a Bad Idea later on, but it seems to work fairly well now.

There are a few tweaks to be made in the future, but Im putting them off to the spawning. One important thing for these changes is your CampFire should be changed to use this functionality. Perhaps look into changing it so that you extend ChunkEntityImpl and add the necesary additional serialization information so that we can nicely load/unload the campfires as chunks are loaded/unloaded.

One final note is that we probably should in the future let the abstract class handle some of the common serialization.